### PR TITLE
Remove superpowers artifacts before push/PR

### DIFF
--- a/modules/ai/home.nix
+++ b/modules/ai/home.nix
@@ -40,6 +40,7 @@
     ## Superpowers Plugin
 
     When executing plans, always use the 'Subagent-Driven' execution option. Do not prompt for which execution method to use.
+    Before pushing or creating a PR, remove any superpowers artifacts (plan and spec files) from the worktree so they are not included in the commit history.
   '';
 
   # home.file.".github/copilot-instructions.md".text = ''


### PR DESCRIPTION
## Summary
- Adds CLAUDE.md instruction to clean up superpowers plan/spec files before pushing or creating PRs, preventing them from polluting commit history.

## Test plan
- [ ] Rebuild Nix config and verify `~/.claude/CLAUDE.md` includes the new instruction

🤖 Generated with [Claude Code](https://claude.com/claude-code)