### PR TITLE
Change claude alias to use auto permission mode

### DIFF
--- a/modules/ai/home.nix
+++ b/modules/ai/home.nix
@@ -61,5 +61,5 @@
     ".claude/settings.local.json"
   ];
 
-  home.shellAliases.claude = "claude --permission-mode=bypassPermissions --enable-auto-mode --allow-dangerously-skip-permissions";
+  home.shellAliases.claude = "claude --permission-mode=auto";
 }


### PR DESCRIPTION
## Summary
- Replace `--permission-mode=bypassPermissions --enable-auto-mode --allow-dangerously-skip-permissions` with `--permission-mode=auto` in the claude shell alias

## Test plan
- [ ] Rebuild Nix configuration and verify the alias resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)