### PR TITLE
Remove superpowers artifact cleanup instruction

### DIFF
--- a/modules/ai/home.nix
+++ b/modules/ai/home.nix
@@ -40,7 +40,6 @@
     ## Superpowers Plugin
 
     When executing plans, always use the 'Subagent-Driven' execution option. Do not prompt for which execution method to use.
-    Before pushing or creating a PR, remove any superpowers artifacts (plan and spec files) from the worktree so they are not included in the commit history.
   '';
 
   # home.file.".github/copilot-instructions.md".text = ''


### PR DESCRIPTION
## Summary
- Remove the instruction to clean up superpowers artifacts before pushing/creating PRs from the global CLAUDE.md.

## Test plan
- [ ] Verify home.nix still evaluates cleanly