### PR TITLE
Trust ~/Developer/cvent-internal in mise config

### DIFF
--- a/modules/home.nix
+++ b/modules/home.nix
@@ -20,7 +20,7 @@
     enable = true;
     enableZshIntegration = true;
     settings = {
-      trusted_config_paths = [ "~/Developer/cvent-internal" ];
+      trusted_config_paths = ["~/Developer/cvent-internal"];
     };
   };
   programs.neovim = {

--- a/modules/home.nix
+++ b/modules/home.nix
@@ -19,6 +19,9 @@
   programs.mise = {
     enable = true;
     enableZshIntegration = true;
+    settings = {
+      trusted_config_paths = [ "~/Developer/cvent-internal" ];
+    };
   };
   programs.neovim = {
     defaultEditor = true;


### PR DESCRIPTION
## Summary
- Adds `~/Developer/cvent-internal` to mise's `trusted_config_paths` so mise tool configs in that directory are trusted without manual prompting.

## Test plan
- [ ] Apply Nix config and verify `mise trust` is no longer prompted in `~/Developer/cvent-internal` repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)