### PR TITLE
feat: add bambu-studio cask

### DIFF
--- a/modules/personal/darwin.nix
+++ b/modules/personal/darwin.nix
@@ -10,6 +10,7 @@
     # The GUI is not available in nixpkgs
     "tailscale-app"
     "balenaetcher"
+    "bambu-studio"
     # Not available in nixpkgs
     "chrome-remote-desktop-host"
   ];


### PR DESCRIPTION
## Summary

- Add bambu-studio Homebrew cask for 3D printing software
- Installed via Homebrew since package is Linux-only in nixpkgs
- Only applies to personal profile machines (not Cvent)