### PR TITLE
feat: switch from vscode insiders cask to vscode nixpkg

### DIFF
--- a/modules/darwin.nix
+++ b/modules/darwin.nix
@@ -43,8 +43,6 @@
       "oversight"
       # https://github.com/warpdotdev/Warp/issues/1991
       "warp"
-      # Insiders is not available in nixpkgs
-      "visual-studio-code@insiders"
       # Cannot allow screensharing with nix package
       "zoom"
     ];

--- a/modules/home.nix
+++ b/modules/home.nix
@@ -115,6 +115,7 @@
       tmux
       tree
       unixtools.watch
+      vscode
     ]
     ++ [
       # Language Servers


### PR DESCRIPTION
## Summary
- Remove `visual-studio-code@insiders` from the allowed unfree casks list
- Add `vscode` from nixpkgs to the home packages

## Test plan
- [ ] `darwin-rebuild switch` applies cleanly
- [ ] `code` is available on PATH

🤖 Generated with [Claude Code](https://claude.com/claude-code)