### PR TITLE
chore(ai): gate subagent workflows in CLAUDE.md to reduce token cost

### DIFF
--- a/modules/ai/home.nix
+++ b/modules/ai/home.nix
@@ -33,13 +33,13 @@
     When making compromises in a plan or implementation (e.g., skipping edge cases, using a workaround, deferring a refactor), record them in the most appropriate location (TODO comments in code, project CLAUDE.md, or memory files) so that future sessions can resolve them.
     Commit often to preserve progress, but do not push unless explicitly asked.
     CI runs various targets including lint and unit tests. Run these before pushing (but not necessarily before every commit).
-    Before pushing, dispatch a subagent to review all staged/committed changes that will be pushed. The subagent should act as a critical code reviewer: read every diff hunk looking for bugs, logic errors, missing edge cases, typos, security issues, and unintended behavioral changes. Fix any issues the subagent identifies before pushing.
+    Before pushing, review the diff for bugs, logic errors, missing edge cases, typos, security issues, and unintended behavioral changes; fix anything found. For pushes with large diffs (roughly >300 lines or touching >5 files), dispatch a subagent to do this review instead of self-reviewing.
     When opening a PR, always add the `ai:autofix` label to it (e.g., `gh pr edit --add-label "ai:autofix"`).
     Always create a PR for completed work. PRs are my preferred workflow for reviewing and merging changes.
 
     ## Superpowers Plugin
 
-    When executing plans, always use the 'Subagent-Driven' execution option. Do not prompt for which execution method to use.
+    When executing plans, do not prompt for which execution method to use. Use 'Subagent-Driven' execution when tasks are genuinely independent and parallelizable; for linear or small plans, execute inline.
   '';
 
   # home.file.".github/copilot-instructions.md".text = ''


### PR DESCRIPTION
## Summary

Two small changes to the Nix-managed user-level `CLAUDE.md` aimed at reducing token spend in Claude Code sessions:

- **Pre-push review**: previously always dispatched a subagent for every push. Now the diff is self-reviewed inline, and a subagent is only forked for large diffs (roughly >300 lines or >5 files). Small fixes no longer pay the subagent fork cost.
- **Plan execution**: previously mandated 'Subagent-Driven' for every plan, which forks a subagent per task. Now defaults to inline execution and only uses Subagent-Driven when tasks are genuinely independent and parallelizable.

## Why

Subagent invocations duplicate system-prompt cost and re-read files, so mandating them for all pushes and all plans was expensive without proportionate benefit on small/linear work.

## Test plan

- [ ] Apply Nix config and confirm `~/.claude/CLAUDE.md` reflects the new text
- [ ] Verify a small change push triggers inline self-review (no subagent fork)
- [ ] Verify a large change push still dispatches the review subagent