### PR TITLE
Add mempalace nix package and install in AI module

### DIFF
--- a/lib/mkDarwinSystem.nix
+++ b/lib/mkDarwinSystem.nix
@@ -31,6 +31,7 @@ darwin.lib.darwinSystem {
               oktaws = oktaws.packages.${prev.stdenv.hostPlatform.system}.default;
               fnox = prev.callPackage ../pkgs/fnox {};
               gig = prev.callPackage ../pkgs/gig {};
+              mempalace = prev.callPackage ../pkgs/mempalace {};
               trajectory = prev.callPackage ../pkgs/trajectory {};
             })
           ];

--- a/modules/ai/darwin.nix
+++ b/modules/ai/darwin.nix
@@ -14,6 +14,7 @@
   '';
 in {
   environment.systemPackages = [
+    pkgs.mempalace
     pkgs.trajectory
     trajectorySetupAi
   ];

--- a/pkgs/mempalace/default.nix
+++ b/pkgs/mempalace/default.nix
@@ -1,0 +1,39 @@
+{
+  fetchFromGitHub,
+  lib,
+  python3Packages,
+}:
+python3Packages.buildPythonApplication {
+  pname = "mempalace";
+  version = "3.5.0";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "mempalace";
+    repo = "mempalace";
+    tag = "v3.5.0";
+    hash = "sha256-C4KPtHNTHTwQXgWUsiRWC0J16tj2wGI7XI/gKGjNgRE=";
+  };
+
+  build-system = [
+    python3Packages.hatchling
+  ];
+
+  dependencies = with python3Packages; [
+    chromadb
+    pyyaml
+    huggingface-hub
+    tokenizers
+    numpy
+    python-dateutil
+  ];
+
+  pythonImportsCheck = [ "mempalace" ];
+
+  meta = {
+    description = "Give your AI a memory — mine projects and conversations into a searchable palace";
+    homepage = "https://github.com/mempalace/mempalace";
+    license = lib.licenses.mit;
+    mainProgram = "mempalace";
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `pkgs/mempalace/default.nix` — packages [mempalace v3.5.0](https://github.com/mempalace/mempalace) as a Python application using `buildPythonApplication`
- Registers it in the nixpkgs overlay in `lib/mkDarwinSystem.nix`
- Adds `pkgs.mempalace` to `environment.systemPackages` in `modules/ai/darwin.nix`

## Test plan

- [ ] `nix build --impure --expr 'with import (builtins.getFlake "github:NixOS/nixpkgs/nixpkgs-26.05-darwin") {}; callPackage ./pkgs/mempalace {}'` — builds successfully ✅
- [ ] `darwin-rebuild switch` on a Darwin machine installs `mempalace` and `mempalace-mcp` binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)