### PR TITLE
Add ollama via Homebrew to AI darwin module

### DIFF
--- a/modules/ai/darwin.nix
+++ b/modules/ai/darwin.nix
@@ -22,6 +22,10 @@ in {
   # Any brews/casks MUST be justified as to why they are
   # not being installed as a nix package.
   homebrew = {
+    brews = [
+      # ollama's launchd service integration is only available via Homebrew on macOS.
+      "ollama"
+    ];
     casks = [
       # Codex Desktop is distributed as a Homebrew cask.
       "codex-app"

--- a/pkgs/mempalace/default.nix
+++ b/pkgs/mempalace/default.nix
@@ -28,7 +28,7 @@ python3Packages.buildPythonApplication {
     python-dateutil
   ];
 
-  pythonImportsCheck = [ "mempalace" ];
+  pythonImportsCheck = ["mempalace"];
 
   meta = {
     description = "Give your AI a memory — mine projects and conversations into a searchable palace";


### PR DESCRIPTION
## Summary

- Adds `ollama` as a Homebrew formula in the AI darwin module
- Uses Homebrew rather than `pkgs.ollama` because the brew formula ships launchd service integration for auto-start on macOS

## Test plan

- [ ] `darwin-rebuild switch` applies without errors
- [ ] `ollama` binary is available after rebuild
- [ ] `brew services start ollama` starts the background server

🤖 Generated with [Claude Code](https://claude.com/claude-code)