### PR TITLE
Remove Confluence and Jira MCP tokens from env secrets

### DIFF
--- a/modules/cvent/home.nix
+++ b/modules/cvent/home.nix
@@ -80,14 +80,6 @@
           provider = "bitwarden";
           value = "GitHub Token";
         };
-        JIRA_MCP_TOKEN = {
-          provider = "bitwarden";
-          value = "Jira Token";
-        };
-        CONFLUENCE_MCP_TOKEN = {
-          provider = "bitwarden";
-          value = "Confluence Token";
-        };
         SONARQUBE_MCP_TOKEN = {
           provider = "bitwarden";
           value = "SonarQube MCP Token";


### PR DESCRIPTION
## Summary
- Removes `JIRA_MCP_TOKEN` and `CONFLUENCE_MCP_TOKEN` from the Bitwarden-backed environment secrets in the cvent home module — these tokens are no longer needed.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)