### PR TITLE
Add GitHub Copilot tools

### DIFF
--- a/modules/ai/darwin.nix
+++ b/modules/ai/darwin.nix
@@ -29,6 +29,9 @@ in {
     casks = [
       # Codex Desktop is distributed as a Homebrew cask.
       "codex-app"
+      # GitHub Copilot CLI and desktop app are distributed as Homebrew casks.
+      "copilot-cli"
+      "github-copilot-app"
     ];
   };
 }

--- a/modules/home.nix
+++ b/modules/home.nix
@@ -45,6 +45,7 @@ in {
     globalConfig.settings = {
       trusted_config_paths = [
         "~/Developer/cvent-internal"
+        "~/Developer/copilot-worktrees"
         "~/.codex/worktrees"
       ];
     };


### PR DESCRIPTION
## Summary

- Install the GitHub Copilot CLI and desktop app via Homebrew casks
- Trust `~/Developer/copilot-worktrees` in mise

## Validation

- Evaluated the Darwin configuration for the Copilot casks and mise trusted path.