### PR TITLE
fix(cvent): use wrapper script for git SSH signing with Bitwarden

### DIFF
--- a/modules/cvent/darwin.nix
+++ b/modules/cvent/darwin.nix
@@ -99,5 +99,11 @@ in {
   ];
 
   environment.variables.SSH_AUTH_SOCK = "/Users/${config.system.primaryUser}/Library/Containers/com.bitwarden.desktop/Data/.bitwarden-ssh-agent.sock";
-  home-manager.users.${config.system.primaryUser}.programs.ssh.settings."*".IdentityAgent = "\"/Users/${config.system.primaryUser}/Library/Containers/com.bitwarden.desktop/Data/.bitwarden-ssh-agent.sock\"";
+  home-manager.users.${config.system.primaryUser} = {
+    programs.git.settings.gpg.ssh.program = toString (pkgs.writeShellScript "bw-ssh-sign" ''
+      export SSH_AUTH_SOCK="/Users/${config.system.primaryUser}/Library/Containers/com.bitwarden.desktop/Data/.bitwarden-ssh-agent.sock"
+      exec ${lib.getExe' pkgs.openssh "ssh-keygen"} "$@"
+    '');
+    programs.ssh.settings."*".IdentityAgent = "\"/Users/${config.system.primaryUser}/Library/Containers/com.bitwarden.desktop/Data/.bitwarden-ssh-agent.sock\"";
+  };
 }


### PR DESCRIPTION
Set `gpg.ssh.program` to a wrapper script that hardcodes `SSH_AUTH_SOCK` pointing to Bitwarden's SSH agent socket.

This ensures git commit signing works in all terminal sessions, even those that don't inherit the environment variable (e.g. IDE terminals, tmux sessions started before login).

The wrapper calls openssh's `ssh-keygen` (which is the correct signing program for Bitwarden) but guarantees the agent socket is always reachable.