### PR TITLE
docs: prefer behavioral skill evaluations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,7 @@
 # nixpkgs
 
+## Testing
+
+Avoid tests that only assert static file contents. For skills, prefer evaluations that exercise the skill's behavior and validate its outcomes.
+
 After creating a PR in this repository, enable automerge on it (e.g., `gh pr merge --auto --squash`).


### PR DESCRIPTION
## Summary
- discourage tests that only assert static file contents
- prefer skill evaluations that exercise behavior and validate outcomes