### PR TITLE
feat(git): ignore root worktrees

### DIFF
--- a/docs/superpowers/specs/2026-07-21-global-worktrees-ignore-design.md
+++ b/docs/superpowers/specs/2026-07-21-global-worktrees-ignore-design.md
@@ -1,0 +1,29 @@
+# Global Worktrees Ignore Design
+
+## Goal
+
+Prevent Git from showing Superpowers-created root-level `.worktrees`
+directories as untracked content in every repository managed by this user
+configuration.
+
+## Design
+
+Append `/.worktrees/` to `programs.git.ignores` in `modules/git/home.nix`.
+Home Manager will combine this local rule with the existing platform-specific
+global ignore patterns fetched from GitHub.
+
+The leading slash restricts the pattern to a repository-root `.worktrees`
+directory. Nested directories with that name remain visible to Git, avoiding a
+broader global exclusion than needed.
+
+## Verification
+
+Run `nix fmt` and `nix flake check`. Confirm the evaluated source list contains
+both the fetched platform ignore rules and `/.worktrees/`, then review the diff
+for a single added ignore pattern.
+
+## Out of Scope
+
+- Adding a `.worktrees` rule to repository `.gitignore` files.
+- Ignoring nested `.worktrees` directories.
+- Creating or applying a Nix Darwin switch.

--- a/modules/git/home.nix
+++ b/modules/git/home.nix
@@ -23,11 +23,15 @@ in {
       key = specialArgs.sshKeys."github.com";
       signByDefault = true;
     };
-    ignores = lib.splitString "\n" (builtins.readFile "${gitignores}/Global/${
-      if pkgs.stdenv.isDarwin
-      then "macOS"
-      else "Linux"
-    }.gitignore");
+    ignores =
+      lib.splitString "\n" (builtins.readFile "${gitignores}/Global/${
+        if pkgs.stdenv.isDarwin
+        then "macOS"
+        else "Linux"
+      }.gitignore")
+      ++ [
+        "/.worktrees/"
+      ];
     settings = {
       user = {
         name = "Jonathan Morley";


### PR DESCRIPTION
## Summary

- add `/.worktrees/` to the Nix-managed global Git ignore list
- document the root-only ignore design

## Verification

- `nix fmt`
- `nix flake check`
