### PR TITLE
fix(cvent): preserve OpenCode desktop fnox environment

### DIFF
--- a/cert-check.nix
+++ b/cert-check.nix
@@ -11,6 +11,12 @@
         cventEnvironment = cventConfig.environment.variables;
         systemCertificates = pkgs.writeText "system-certificates.pem" (lib.concatStringsSep "\n" cventConfig.security.pki.certificates);
         activationScript = pkgs.writeText "activation-script" cventConfig.system.activationScripts.extraActivation.text;
+        cventOpencodeDesktop = self.darwinConfigurations.D3W27G1QW9.pkgs.opencode-desktop;
+        ghaOpencodeDesktop = self.darwinConfigurations.gha-aarch64-darwin.pkgs.opencode-desktop;
+        cventMakeBinaryWrapper = self.darwinConfigurations.D3W27G1QW9.pkgs.makeBinaryWrapper;
+        ghaMakeBinaryWrapper = self.darwinConfigurations.gha-aarch64-darwin.pkgs.makeBinaryWrapper;
+        cventProfileBin = "/etc/profiles/per-user/${self.darwinConfigurations.D3W27G1QW9.config.system.primaryUser}/bin";
+        ghaProfileBin = "/etc/profiles/per-user/${self.darwinConfigurations.gha-aarch64-darwin.config.system.primaryUser}/bin";
       in {
         certificates = pkgs.runCommand "certificate-tests" {nativeBuildInputs = [pkgs.openssl];} ''
           ${./tests/certs-static.sh} \
@@ -22,6 +28,55 @@
             ${cventEnvironment.SSL_CERT_FILE} \
             ${cventEnvironment.REQUESTS_CA_BUNDLE} \
             ${cventEnvironment.BUNDLE_SSL_CA_CERT}
+          touch "$out"
+        '';
+
+        opencode-desktop-fnox-wrap = pkgs.runCommand "opencode-desktop-fnox-wrap-tests" {} ''
+          assert_wrapper() {
+            local configuration="$1"
+            local post_install="$2"
+            local fnox="$3"
+            local native_build_inputs="$4"
+            local make_binary_wrapper="$5"
+            local profile_bin="$6"
+
+            if [[ "$post_install" != *".OpenCode-unwrapped"* ]]; then
+              echo "$configuration opencode-desktop fnox wrapper assertion failed: postInstall is missing .OpenCode-unwrapped" >&2
+              return 1
+            fi
+
+            if [[ "$post_install" != *"makeBinaryWrapper $fnox"* ]]; then
+              echo "$configuration opencode-desktop fnox wrapper assertion failed: postInstall is missing makeBinaryWrapper $fnox" >&2
+              return 1
+            fi
+
+            if [[ "$native_build_inputs" != *"$make_binary_wrapper"* ]]; then
+              echo "$configuration opencode-desktop fnox wrapper assertion failed: nativeBuildInputs is missing $make_binary_wrapper" >&2
+              return 1
+            fi
+
+            if [[ "$post_install" != *"--prefix PATH : \"$profile_bin\""* ]]; then
+              echo "$configuration opencode-desktop fnox wrapper assertion failed: postInstall is missing profile PATH prefix $profile_bin" >&2
+              return 1
+            fi
+          }
+
+          assert_wrapper \
+            gha-aarch64-darwin \
+            ${lib.escapeShellArg (ghaOpencodeDesktop.postInstall or "")} \
+            ${lib.escapeShellArg "${self.darwinConfigurations.gha-aarch64-darwin.pkgs.fnox}/bin/fnox"} \
+            ${lib.escapeShellArg (lib.concatStringsSep "\n" (map toString (ghaOpencodeDesktop.nativeBuildInputs or [])))} \
+            ${lib.escapeShellArg (toString ghaMakeBinaryWrapper)} \
+            ${lib.escapeShellArg ghaProfileBin}
+          echo "gha-aarch64-darwin opencode-desktop fnox wrapper assertion passed"
+
+          assert_wrapper \
+            D3W27G1QW9 \
+            ${lib.escapeShellArg (cventOpencodeDesktop.postInstall or "")} \
+            ${lib.escapeShellArg "${self.darwinConfigurations.D3W27G1QW9.pkgs.fnox}/bin/fnox"} \
+            ${lib.escapeShellArg (lib.concatStringsSep "\n" (map toString (cventOpencodeDesktop.nativeBuildInputs or [])))} \
+            ${lib.escapeShellArg (toString cventMakeBinaryWrapper)} \
+            ${lib.escapeShellArg cventProfileBin}
           touch "$out"
         '';
       }

--- a/modules/ai/darwin.nix
+++ b/modules/ai/darwin.nix
@@ -17,6 +17,7 @@
   opencodeDesktopOverlay = final: prev:
     lib.optionalAttrs prev.stdenv.hostPlatform.isAarch64 {
       opencode-desktop = prev.opencode-desktop.overrideAttrs (old: {
+        nativeBuildInputs = (old.nativeBuildInputs or []) ++ [final.makeBinaryWrapper];
         postInstall =
           (old.postInstall or "")
           + ''
@@ -27,6 +28,7 @@
 
             makeBinaryWrapper ${lib.getExe final.fnox} "$app" \
               --inherit-argv0 \
+              --prefix PATH : "/etc/profiles/per-user/${config.system.primaryUser}/bin" \
               --add-flags "exec" \
               --add-flags "--" \
               --add-flags "$original"

--- a/modules/cvent/darwin.nix
+++ b/modules/cvent/darwin.nix
@@ -65,7 +65,28 @@ in {
     })
     (_final: _prev: {
       opencode = cventOpencode;
-      opencode-desktop = cventOpencodeDesktop;
+      opencode-desktop =
+        if _final.stdenv.hostPlatform.isAarch64
+        then
+          cventOpencodeDesktop.overrideAttrs (old: {
+            nativeBuildInputs = (old.nativeBuildInputs or []) ++ [_final.makeBinaryWrapper];
+            postInstall =
+              (old.postInstall or "")
+              + ''
+                app="$out/Applications/OpenCode.app/Contents/MacOS/OpenCode"
+                original="$out/Applications/OpenCode.app/Contents/MacOS/.OpenCode-unwrapped"
+
+                mv "$app" "$original"
+
+                makeBinaryWrapper ${lib.getExe _final.fnox} "$app" \
+                  --inherit-argv0 \
+                  --prefix PATH : "/etc/profiles/per-user/${config.system.primaryUser}/bin" \
+                  --add-flags "exec" \
+                  --add-flags "--" \
+                  --add-flags "$original"
+              '';
+          })
+        else cventOpencodeDesktop;
     })
   ];
 


### PR DESCRIPTION
## Summary
- Preserve the fnox wrapper after the Cvent OpenCode Desktop CA override.
- Add the binary-wrapper build hook and profile PATH needed for Bitwarden-backed environment resolution.
- Add a derivation-level regression check for the Cvent and GHA desktop wrappers.

## Verification
- nix flake check --no-update-lock-file .
- sudo darwin-rebuild switch --flake .#D3W27G1QW9
- Fresh OpenCode process contains Sourcegraph and CA environment variables; values were not printed.